### PR TITLE
Updated to enable persist of the snowball-arenas object. 

### DIFF
--- a/chapter-19/arena.js
+++ b/chapter-19/arena.js
@@ -8,6 +8,10 @@ var instructions = [
   '/jsp snowball'
 ];
 
+// Added reference to prevent persist() object thrashing when called externally
+function getArena() {
+  return arenas;
+
 function snowballArena() {
   var arena = {};
   
@@ -67,4 +71,5 @@ function snowballArena() {
 
 Drone.extend( snowballArena );
 
+exports.getArena = getArena;
 

--- a/chapter-19/arena.js
+++ b/chapter-19/arena.js
@@ -9,7 +9,7 @@ var instructions = [
 ];
 
 // Added reference to prevent persist() object thrashing when called externally
-function getArena() {
+function getArenas() {
   return arenas;
 
 function snowballArena() {
@@ -71,5 +71,5 @@ function snowballArena() {
 
 Drone.extend( snowballArena );
 
-exports.getArena = getArena;
+exports.getArenas = getArenas;
 

--- a/chapter-19/command.js
+++ b/chapter-19/command.js
@@ -4,7 +4,7 @@ var utils = require('utils');
 var cm = Packages.net.canarymod;
 var cmLocation = cm.api.world.position.Location;
 var game = require('./game');
-var arenas = persist('snowball-arenas', []);
+
 
 function snowball( params, sender ){
   var duration = 60; // seconds
@@ -17,6 +17,9 @@ function snowball( params, sender ){
   var teams = {red: [], blue:[], yellow:[]};
   var spawns = [];
   var spawn = null;
+// use local arenas object reference from arenas.js, rather than creating another global one. Seemed to cause issues when it was global.
+  var aplugin = require('./arena');
+  var arenas = aplugin.getArena();
 
   for ( i = 0; i < arenas.length; i++ ) {
     arena = arenas[i];

--- a/chapter-19/command.js
+++ b/chapter-19/command.js
@@ -19,7 +19,7 @@ function snowball( params, sender ){
   var spawn = null;
 // use local arenas object reference from arenas.js, rather than creating another global one. Seemed to cause issues when it was global.
   var aplugin = require('./arena');
-  var arenas = aplugin.getArena();
+  var arenas = aplugin.getArenas();
 
   for ( i = 0; i < arenas.length; i++ ) {
     arena = arenas[i];


### PR DESCRIPTION
The current version of the game doesn't appear to persist to the filesystem correctly for snowball-arenas (it doesn't write to the file when it's unloaded, or when js refresh() is issued).  The thinking was to only have a single object reference to the persist object() through getArena() and expose it externally to  the snowball command in Command.js  It's entirely possible (and likely), there's a more elegant way to fix this. Would love to get your insight.
